### PR TITLE
fix!: correctly deserialize deleted iterations

### DIFF
--- a/src/api/v2.rs
+++ b/src/api/v2.rs
@@ -273,14 +273,19 @@ impl Client {
     ///         .credentials(credentials)
     ///         .build()?;
     ///
-    ///     Ok(client
+    ///     let submission_uuid = client
     ///         .get_solution(solution_uuid, true)
     ///         .await?
     ///         .iterations
     ///         .into_iter()
     ///         .find(|iteration| iteration.is_latest)
-    ///         .map(|iteration| iteration.files)
-    ///         .unwrap_or_default())
+    ///         .and_then(|iteration| iteration.submission_uuid)
+    ///         .ok_or_else(|| anyhow::anyhow!("could not find submission uuid"))?;
+    ///
+    ///     Ok(client
+    ///         .get_submission_files(solution_uuid, &submission_uuid)
+    ///         .await?
+    ///         .files)
     /// }
     /// ```
     ///

--- a/src/api/v2/iteration.rs
+++ b/src/api/v2/iteration.rs
@@ -2,6 +2,8 @@
 //!
 //! Solutions to exercises can have multiple iterations.
 
+pub(crate) mod detail;
+
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display, IntoStaticStr};
 
@@ -18,7 +20,10 @@ pub struct Iteration {
     /// Unique ID of the iteration's submission.
     ///
     /// An iteration's submission is tied to the actual data sent for the iteration.
-    pub submission_uuid: String,
+    ///
+    /// Will be `None` for deleted iterations.
+    #[serde(default)]
+    pub submission_uuid: Option<String>,
 
     /// 1-based index of the iteration.
     ///
@@ -77,7 +82,7 @@ pub struct Iteration {
     ///
     /// This field is only filled if automated feedback is sideloaded, which is not currently possible with the
     /// v2 API [`Client`](crate::api::v2::Client).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "detail::deserialize_optional_feedback")]
     pub representer_feedback: Option<RepresenterFeedback>,
 
     /// Feedback provided by the track's [analyzer](https://exercism.org/docs/building/tooling/analyzers) for
@@ -89,7 +94,7 @@ pub struct Iteration {
     ///
     /// This field is only filled if automated feedback is sideloaded, which is not currently possible with the
     /// v2 API [`Client`](crate::api::v2::Client).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "detail::deserialize_optional_feedback")]
     pub analyzer_feedback: Option<AnalyzerFeedback>,
 
     /// Whether this iteration has been published.
@@ -98,6 +103,13 @@ pub struct Iteration {
     pub is_published: bool,
 
     /// Whether this is the solution's latest iteration.
+    ///
+    /// # Notes
+    ///
+    /// This field is not sent by the v2 API for deleted iterations. Presumably, if the
+    /// last iteration of a solution is deleted, then the next-to-last will have `is_latest`
+    /// set to `true` in its stead.
+    #[serde(default)]
     pub is_latest: bool,
 
     /// Information about the iteration's submitted files, including their content.
@@ -194,10 +206,16 @@ pub struct Links {
     pub self_path: String,
 
     /// API URL that can be used to fetch the iteration's submission's automated feedback.
-    pub automated_feedback: String,
+    ///
+    /// Will be `None` if the iteration has no automated feedback (if it is deleted, for example).
+    #[serde(default)]
+    pub automated_feedback: Option<String>,
 
     /// API URL of the iteration. Performing an HTTP `DELETE` on this URL will delete the iteration.
-    pub delete: String,
+    ///
+    /// Will be `None` if the iteration is already deleted.
+    #[serde(default)]
+    pub delete: Option<String>,
 
     /// URL of the exercise on the [Exercism website](https://exercism.org).
     ///
@@ -205,8 +223,14 @@ pub struct Links {
     pub solution: String,
 
     /// API URL of the iteration's submission's test run.
-    pub test_run: String,
+    ///
+    /// Will be `None` if the iteration has no test run (if it is deleted, for example).
+    #[serde(default)]
+    pub test_run: Option<String>,
 
     /// API URL of the iteration's submission's files (with content).
-    pub files: String,
+    ///
+    /// Will be `None` for deleted iterations.
+    #[serde(default)]
+    pub files: Option<String>,
 }

--- a/src/api/v2/iteration/detail.rs
+++ b/src/api/v2/iteration/detail.rs
@@ -1,0 +1,76 @@
+use std::any::type_name;
+use std::fmt::Formatter;
+use std::marker::PhantomData;
+
+use serde::de::value::MapAccessDeserializer;
+use serde::de::{MapAccess, Unexpected, Visitor};
+use serde::{Deserialize, Deserializer};
+
+pub fn deserialize_optional_feedback<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_option(OptionalFeedbackVisitor::new())
+}
+
+struct OptionalFeedbackVisitor<T>(PhantomData<T>);
+
+impl<T> OptionalFeedbackVisitor<T> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<'de, T> Visitor<'de> for OptionalFeedbackVisitor<T>
+where
+    T: Deserialize<'de>,
+{
+    type Value = Option<T>;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        write!(
+            formatter,
+            "an optional feedback struct (of type {}) or the string 'not_queued'",
+            type_name::<T>()
+        )
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        // When deserializing a deleted iteration, the Exercism v2 API sends a string
+        // value of 'not_queued' for representer and analyzer feedback. This might be
+        // a bug as that is a value of the `tests_status` enum. Regardless, we need
+        // to handle this case by considering it like it was not specified (e.g. `null`).
+        //
+        // See https://github.com/clechasseur/exercism-website/blob/0b598e464de39f6cfc53c15ed80879f2e1a4aade/app/serializers/serialize_iteration.rb#L57-L58
+        if v == "not_queued" {
+            Ok(None)
+        } else {
+            Err(E::invalid_value(Unexpected::Str(v), &self))
+        }
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(None)
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(self)
+    }
+
+    fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        Ok(Some(T::deserialize(MapAccessDeserializer::new(map))?))
+    }
+}

--- a/src/api/v2/iteration/detail.rs
+++ b/src/api/v2/iteration/detail.rs
@@ -17,8 +17,12 @@ where
 struct OptionalFeedbackVisitor<T>(PhantomData<T>);
 
 impl<T> OptionalFeedbackVisitor<T> {
-    pub fn new() -> Self {
+    fn new() -> Self {
         Self(PhantomData)
+    }
+
+    fn feedback_type_name(&self) -> &'static str {
+        type_name::<T>().split("::").last().unwrap()
     }
 }
 
@@ -32,7 +36,7 @@ where
         write!(
             formatter,
             "an optional feedback struct (of type {}) or the string 'not_queued'",
-            type_name::<T>()
+            self.feedback_type_name(),
         )
     }
 
@@ -72,5 +76,133 @@ where
         A: MapAccess<'de>,
     {
         Ok(Some(T::deserialize(MapAccessDeserializer::new(map))?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod deserialize_optional_feedback {
+        use assert_matches::assert_matches;
+
+        use super::*;
+        use crate::api::v2::submission::analysis::AnalyzerCommentType::Informative;
+        use crate::api::v2::submission::analysis::{
+            AnalyzerComment, AnalyzerFeedback, FeedbackAuthor, RepresenterFeedback,
+        };
+        use crate::api::v2::user::Flair::LifetimeInsider;
+
+        #[derive(Debug, PartialEq, Eq, Deserialize)]
+        struct TestIteration {
+            #[serde(default, deserialize_with = "deserialize_optional_feedback")]
+            pub representer_feedback: Option<RepresenterFeedback>,
+
+            #[serde(default, deserialize_with = "deserialize_optional_feedback")]
+            pub analyzer_feedback: Option<AnalyzerFeedback>,
+        }
+
+        #[test]
+        fn test_null() {
+            let json = r#"{
+                "representer_feedback": null,
+                "analyzer_feedback": null
+            }"#;
+
+            let expected = TestIteration { representer_feedback: None, analyzer_feedback: None };
+            let actual: TestIteration = serde_json::from_str(json).unwrap();
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn test_not_queued() {
+            let json = r#"{
+                "representer_feedback": "not_queued",
+                "analyzer_feedback": "not_queued"
+            }"#;
+
+            let expected = TestIteration { representer_feedback: None, analyzer_feedback: None };
+            let actual: TestIteration = serde_json::from_str(json).unwrap();
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn test_invalid_string_value() {
+            let json = r#"{
+                "representer_feedback": "foo",
+                "analyzer_feedback": "bar"
+            }"#;
+
+            assert_matches!(serde_json::from_str::<TestIteration>(json), Err(err) => {
+                assert!(err.to_string().contains("an optional feedback struct (of type RepresenterFeedback) or the string 'not_queued'"));
+            });
+        }
+
+        #[test]
+        fn test_map() {
+            let json = r#"{
+                "representer_feedback": {
+                    "html": "<p>This looks great. Thank you for the submission!</p>\n",
+                    "author": {
+                        "name": "John Smith",
+                        "reputation": 12345,
+                        "flair": "lifetime_insider",
+                        "avatar_url": "https://assets.exercism.org/avatars/31337/0",
+                        "profile_url": "https://exercism.org/profiles/jsmith_mini_exercism"
+                    },
+                    "editor": null
+                },
+                "analyzer_feedback": {
+                    "summary": null,
+                    "comments": [
+                        {
+                            "type": "informative",
+                            "html": "<p>Nice work using <code>impl Display</code> to implement to_string.</p>\n"
+                        },
+                        {
+                            "type": "informative",
+                            "html": "<p>Nice work using rem_euclid!</p>\n"
+                        },
+                        {
+                            "type": "informative",
+                            "html": "<p>(Some people don't bother storing the hours in the struct which simplifies things a bit.)</p>\n"
+                        }
+                    ]
+                }
+            }"#;
+
+            let expected = TestIteration {
+                representer_feedback: Some(RepresenterFeedback {
+                    html: "<p>This looks great. Thank you for the submission!</p>\n".into(),
+                    author: FeedbackAuthor {
+                        name: "John Smith".into(),
+                        reputation: 12345,
+                        flair: Some(LifetimeInsider),
+                        avatar_url: "https://assets.exercism.org/avatars/31337/0".into(),
+                        profile_url: Some("https://exercism.org/profiles/jsmith_mini_exercism".into()),
+                    },
+                    editor: None,
+                }),
+                analyzer_feedback: Some(AnalyzerFeedback {
+                    summary: None,
+                    comments: vec![
+                        AnalyzerComment {
+                            comment_type: Informative,
+                            html: "<p>Nice work using <code>impl Display</code> to implement to_string.</p>\n".into(),
+                        },
+                        AnalyzerComment {
+                            comment_type: Informative,
+                            html: "<p>Nice work using rem_euclid!</p>\n".into(),
+                        },
+                        AnalyzerComment {
+                            comment_type: Informative,
+                            html: "<p>(Some people don't bother storing the hours in the struct which simplifies things a bit.)</p>\n".into(),
+                        },
+                    ],
+                }),
+            };
+            let actual: TestIteration = serde_json::from_str(json).unwrap();
+            assert_eq!(expected, actual);
+        }
     }
 }

--- a/tests/v2/iteration.rs
+++ b/tests/v2/iteration.rs
@@ -34,7 +34,7 @@ mod iteration {
 
             let expected = Iteration {
                 uuid: "98f8b04515a8484ca211edc7c56d2aa2".into(),
-                submission_uuid: "ab542af6906349ebb37e7cbee4828554".into(),
+                submission_uuid: Some("ab542af6906349ebb37e7cbee4828554".into()),
                 index: 2,
                 status: NonActionableAutomatedFeedback,
                 num_essential_automated_comments: 0,
@@ -51,11 +51,11 @@ mod iteration {
                 files: vec![],
                 links: Links {
                     self_path: "https://exercism.org/tracks/rust/exercises/clock/iterations?idx=2".into(),
-                    automated_feedback: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2/automated_feedback".into(),
-                    delete: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2".into(),
+                    automated_feedback: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2/automated_feedback".into()),
+                    delete: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2".into()),
                     solution: "https://exercism.org/tracks/rust/exercises/clock".into(),
-                    test_run: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/test_run".into(),
-                    files: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/files".into(),
+                    test_run: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/test_run".into()),
+                    files: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/files".into()),
                 },
             };
             let actual: Iteration = serde_json::from_str(json).unwrap();
@@ -90,7 +90,7 @@ mod iteration {
 
             let expected = Iteration {
                 uuid: "667beaee5e6d4a67a2679545879e6c3f".into(),
-                submission_uuid: "4a41c68afbf343268fe78dd3ce81f44e".into(),
+                submission_uuid: Some("4a41c68afbf343268fe78dd3ce81f44e".into()),
                 index: 2,
                 status: iteration::Status::Unknown,
                 num_essential_automated_comments: 0,
@@ -107,11 +107,11 @@ mod iteration {
                 files: vec![],
                 links: Links {
                     self_path: "https://exercism.org/tracks/rust/exercises/rlyehian/iterations?idx=2".into(),
-                    automated_feedback: "https://exercism.org/api/v2/solutions/826fff5ec5d246aa904c4270126efde9/iterations/667beaee5e6d4a67a2679545879e6c3f/automated_feedback".into(),
-                    delete: "https://exercism.org/api/v2/solutions/826fff5ec5d246aa904c4270126efde9/iterations/667beaee5e6d4a67a2679545879e6c3f".into(),
+                    automated_feedback: Some("https://exercism.org/api/v2/solutions/826fff5ec5d246aa904c4270126efde9/iterations/667beaee5e6d4a67a2679545879e6c3f/automated_feedback".into()),
+                    delete: Some("https://exercism.org/api/v2/solutions/826fff5ec5d246aa904c4270126efde9/iterations/667beaee5e6d4a67a2679545879e6c3f".into()),
                     solution: "https://exercism.org/tracks/rust/exercises/rlyehian".into(),
-                    test_run: "https://exercism.org/api/v2/solutions/826fff5ec5d246aa904c4270126efde9/submissions/4a41c68afbf343268fe78dd3ce81f44e/test_run".into(),
-                    files: "https://exercism.org/api/v2/solutions/826fff5ec5d246aa904c4270126efde9/submissions/4a41c68afbf343268fe78dd3ce81f44e/files".into(),
+                    test_run: Some("https://exercism.org/api/v2/solutions/826fff5ec5d246aa904c4270126efde9/submissions/4a41c68afbf343268fe78dd3ce81f44e/test_run".into()),
+                    files: Some("https://exercism.org/api/v2/solutions/826fff5ec5d246aa904c4270126efde9/submissions/4a41c68afbf343268fe78dd3ce81f44e/files".into()),
                 },
             };
             let actual: Iteration = serde_json::from_str(json).unwrap();
@@ -122,7 +122,7 @@ mod iteration {
         fn test_deleted() {
             // Deleted iterations have a strange string value ('not_queued') in the feedback fields.
             // This used to break our parsing.
-            
+
             let json = r#"{
                 "uuid": "da0ae7d7b6804c49ba988197ee88f072",
                 "idx": 7,
@@ -145,7 +145,7 @@ mod iteration {
 
             let expected = Iteration {
                 uuid: "da0ae7d7b6804c49ba988197ee88f072".into(),
-                submission_uuid: String::new(),
+                submission_uuid: None,
                 index: 7,
                 status: iteration::Status::Deleted,
                 num_essential_automated_comments: 0,
@@ -161,12 +161,13 @@ mod iteration {
                 is_latest: false,
                 files: vec![],
                 links: Links {
-                    self_path: "https://exercism.org/tracks/rust/exercises/poker/iterations?idx=7".into(),
-                    automated_feedback: String::new(),
-                    delete: String::new(),
+                    self_path: "https://exercism.org/tracks/rust/exercises/poker/iterations?idx=7"
+                        .into(),
+                    automated_feedback: None,
+                    delete: None,
                     solution: "https://exercism.org/tracks/rust/exercises/poker".into(),
-                    test_run: String::new(),
-                    files: String::new(),
+                    test_run: None,
+                    files: None,
                 },
             };
             let actual: Iteration = serde_json::from_str(json).unwrap();
@@ -181,7 +182,7 @@ mod links {
 
         #[test]
         fn test_all() {
-            let json = r#" {
+            let json = r#"{
                 "self": "https://exercism.org/tracks/rust/exercises/clock/iterations?idx=2",
                 "automated_feedback": "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2/automated_feedback",
                 "delete": "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2",
@@ -192,11 +193,34 @@ mod links {
 
             let expected = Links {
                 self_path: "https://exercism.org/tracks/rust/exercises/clock/iterations?idx=2".into(),
-                automated_feedback: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2/automated_feedback".into(),
-                delete: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2".into(),
+                automated_feedback: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2/automated_feedback".into()),
+                delete: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2".into()),
                 solution: "https://exercism.org/tracks/rust/exercises/clock".into(),
-                test_run: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/test_run".into(),
-                files: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/files".into(),
+                test_run: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/test_run".into()),
+                files: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/files".into()),
+            };
+            let actual: Links = serde_json::from_str(json).unwrap();
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn test_deleted() {
+            // Deleted iterations only have minimal information.
+            // This used to break our parsing because all fields were mandatory.
+
+            let json = r#"{
+                "self": "https://exercism.org/tracks/rust/exercises/poker/iterations?idx=7",
+                "solution": "https://exercism.org/tracks/rust/exercises/poker"
+            }"#;
+
+            let expected = Links {
+                self_path: "https://exercism.org/tracks/rust/exercises/poker/iterations?idx=7"
+                    .into(),
+                automated_feedback: None,
+                delete: None,
+                solution: "https://exercism.org/tracks/rust/exercises/poker".into(),
+                test_run: None,
+                files: None,
             };
             let actual: Links = serde_json::from_str(json).unwrap();
             assert_eq!(expected, actual);

--- a/tests/v2/iteration.rs
+++ b/tests/v2/iteration.rs
@@ -55,8 +55,8 @@ mod iteration {
                     delete: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2".into(),
                     solution: "https://exercism.org/tracks/rust/exercises/clock".into(),
                     test_run: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/test_run".into(),
-                    files: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/files".into()
-                }
+                    files: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/files".into(),
+                },
             };
             let actual: Iteration = serde_json::from_str(json).unwrap();
             assert_eq!(expected, actual);
@@ -111,8 +111,63 @@ mod iteration {
                     delete: "https://exercism.org/api/v2/solutions/826fff5ec5d246aa904c4270126efde9/iterations/667beaee5e6d4a67a2679545879e6c3f".into(),
                     solution: "https://exercism.org/tracks/rust/exercises/rlyehian".into(),
                     test_run: "https://exercism.org/api/v2/solutions/826fff5ec5d246aa904c4270126efde9/submissions/4a41c68afbf343268fe78dd3ce81f44e/test_run".into(),
-                    files: "https://exercism.org/api/v2/solutions/826fff5ec5d246aa904c4270126efde9/submissions/4a41c68afbf343268fe78dd3ce81f44e/files".into()
+                    files: "https://exercism.org/api/v2/solutions/826fff5ec5d246aa904c4270126efde9/submissions/4a41c68afbf343268fe78dd3ce81f44e/files".into(),
+                },
+            };
+            let actual: Iteration = serde_json::from_str(json).unwrap();
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn test_deleted() {
+            // Deleted iterations have a strange string value ('not_queued') in the feedback fields.
+            // This used to break our parsing.
+            
+            let json = r#"{
+                "uuid": "da0ae7d7b6804c49ba988197ee88f072",
+                "idx": 7,
+                "status": "deleted",
+                "num_essential_automated_comments": 0,
+                "num_actionable_automated_comments": 0,
+                "num_non_actionable_automated_comments": 0,
+                "num_celebratory_automated_comments": 0,
+                "submission_method": "cli",
+                "created_at": "2023-04-21T00:46:28Z",
+                "tests_status": "not_queued",
+                "representer_feedback": "not_queued",
+                "analyzer_feedback": "not_queued",
+                "is_published": false,
+                "links": {
+                    "self": "https://exercism.org/tracks/rust/exercises/poker/iterations?idx=7",
+                    "solution": "https://exercism.org/tracks/rust/exercises/poker"
                 }
+            }"#;
+
+            let expected = Iteration {
+                uuid: "da0ae7d7b6804c49ba988197ee88f072".into(),
+                submission_uuid: String::new(),
+                index: 7,
+                status: iteration::Status::Deleted,
+                num_essential_automated_comments: 0,
+                num_actionable_automated_comments: 0,
+                num_non_actionable_automated_comments: 0,
+                num_celebratory_automated_comments: 0,
+                submission_method: "cli".into(),
+                created_at: "2023-04-21T00:46:28Z".into(),
+                tests_status: tests::Status::NotQueued,
+                representer_feedback: None,
+                analyzer_feedback: None,
+                is_published: false,
+                is_latest: false,
+                files: vec![],
+                links: Links {
+                    self_path: "https://exercism.org/tracks/rust/exercises/poker/iterations?idx=7".into(),
+                    automated_feedback: String::new(),
+                    delete: String::new(),
+                    solution: "https://exercism.org/tracks/rust/exercises/poker".into(),
+                    test_run: String::new(),
+                    files: String::new(),
+                },
             };
             let actual: Iteration = serde_json::from_str(json).unwrap();
             assert_eq!(expected, actual);
@@ -141,7 +196,7 @@ mod links {
                 delete: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2".into(),
                 solution: "https://exercism.org/tracks/rust/exercises/clock".into(),
                 test_run: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/test_run".into(),
-                files: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/files".into()
+                files: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/files".into(),
             };
             let actual: Links = serde_json::from_str(json).unwrap();
             assert_eq!(expected, actual);

--- a/tests/v2/mod.rs
+++ b/tests/v2/mod.rs
@@ -589,7 +589,7 @@ mod client {
                 iterations: vec![
                     Iteration {
                         uuid: "98f8b04515a8484ca211edc7c56d2aa2".into(),
-                        submission_uuid: "ab542af6906349ebb37e7cbee4828554".into(),
+                        submission_uuid: Some("ab542af6906349ebb37e7cbee4828554".into()),
                         index: 1,
                         status: NonActionableAutomatedFeedback,
                         num_essential_automated_comments: 0,
@@ -606,11 +606,11 @@ mod client {
                         files: vec![],
                         links: Links {
                             self_path: "https://exercism.org/tracks/rust/exercises/clock/iterations?idx=2".into(),
-                            automated_feedback: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2/automated_feedback".into(),
-                            delete: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2".into(),
+                            automated_feedback: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2/automated_feedback".into()),
+                            delete: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2".into()),
                             solution: "https://exercism.org/tracks/rust/exercises/clock".into(),
-                            test_run: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/test_run".into(),
-                            files: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/files".into()
+                            test_run: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/test_run".into()),
+                            files: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/files".into()),
                         },
                     },
                 ],
@@ -642,7 +642,7 @@ mod client {
             assert!(!iterations.is_empty());
             let iteration = iterations.first().unwrap();
             assert_eq!("98f8b04515a8484ca211edc7c56d2aa2", iteration.uuid);
-            assert_eq!("ab542af6906349ebb37e7cbee4828554", iteration.submission_uuid);
+            assert_eq!(Some("ab542af6906349ebb37e7cbee4828554".into()), iteration.submission_uuid);
             assert_eq!(1, iteration.index);
             assert!(iteration.is_latest);
         }

--- a/tests/v2/solution.rs
+++ b/tests/v2/solution.rs
@@ -99,7 +99,7 @@ mod response {
                 iterations: vec![
                     Iteration {
                         uuid: "98f8b04515a8484ca211edc7c56d2aa2".into(),
-                        submission_uuid: "ab542af6906349ebb37e7cbee4828554".into(),
+                        submission_uuid: Some("ab542af6906349ebb37e7cbee4828554".into()),
                         index: 1,
                         status: NonActionableAutomatedFeedback,
                         num_essential_automated_comments: 0,
@@ -116,11 +116,11 @@ mod response {
                         files: vec![],
                         links: Links {
                             self_path: "https://exercism.org/tracks/rust/exercises/clock/iterations?idx=2".into(),
-                            automated_feedback: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2/automated_feedback".into(),
-                            delete: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2".into(),
+                            automated_feedback: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2/automated_feedback".into()),
+                            delete: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/iterations/98f8b04515a8484ca211edc7c56d2aa2".into()),
                             solution: "https://exercism.org/tracks/rust/exercises/clock".into(),
-                            test_run: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/test_run".into(),
-                            files: "https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/files".into()
+                            test_run: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/test_run".into()),
+                            files: Some("https://exercism.org/api/v2/solutions/a0c9664059d345ac8d677b0154794ff2/submissions/ab542af6906349ebb37e7cbee4828554/files".into()),
                         },
                     },
                 ],


### PR DESCRIPTION
This PR fixes the deserialization of deleted iterations which are sent quite differently by the Exercism v2 API.

Note that this is a breaking change, because the API surface of the crate had to change to accomodate optional fields.